### PR TITLE
fix: now officially supporting react 16

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 npm install heksher # or yarn add heksher or pnpm add heksher
 ```
 
-Heksher requires `react@16.3.0` or newer to work, this is because in this version of react the new context api was introduced.
+Heksher requires `react@16.9.0` or newer in order to work.
 
 ## Getting Started
 Lets suppose we are creating a game app and we want to tell our entire app the current time (which is fetched from the server).

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,13 +8,17 @@
       "name": "heksher",
       "version": "0.1.1",
       "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.0"
+      },
       "devDependencies": {
-        "@types/react": ">16.3.0",
+        "@types/react": ">16.9.0",
+        "@types/use-sync-external-store": "^0.0.6",
         "tsup": "^8.0.1",
         "typescript": "^5.3.2"
       },
       "peerDependencies": {
-        "react": ">16.3.0"
+        "react": ">16.9.0"
       }
     },
     "node_modules/@esbuild/android-arm": {
@@ -615,9 +619,9 @@
       "dev": true
     },
     "node_modules/@types/react": {
-      "version": "18.2.38",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.38.tgz",
-      "integrity": "sha512-cBBXHzuPtQK6wNthuVMV6IjHAFkdl/FOPFIlkd81/Cd1+IqkHu/A+w4g43kaQQoYHik/ruaQBDL72HyCy1vuMw==",
+      "version": "18.2.47",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.47.tgz",
+      "integrity": "sha512-xquNkkOirwyCgoClNk85BjP+aqnIS+ckAJ8i37gAbDs14jfW/J23f2GItAf33oiUPQnqNMALiFeoM9Y5mbjpVQ==",
       "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
@@ -629,6 +633,12 @@
       "version": "0.16.8",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.8.tgz",
       "integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==",
+      "dev": true
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "dev": true
     },
     "node_modules/any-promise": {
@@ -777,9 +787,9 @@
       }
     },
     "node_modules/csstype": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
-      "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "dev": true
     },
     "node_modules/debug": {
@@ -1665,6 +1675,14 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
-    "build": "tsup"
+    "build": "tsup",
+    "prepack": "npm run build"
   },
   "files": [
     "lib/"
@@ -23,11 +24,15 @@
   },
   "homepage": "https://github.com/dorilahav/heksher",
   "peerDependencies": {
-    "react": ">16.3.0"
+    "react": ">16.9.0"
   },
   "devDependencies": {
-    "@types/react": ">16.3.0",
+    "@types/react": ">16.9.0",
+    "@types/use-sync-external-store": "^0.0.6",
     "tsup": "^8.0.1",
     "typescript": "^5.3.2"
+  },
+  "dependencies": {
+    "use-sync-external-store": "^1.2.0"
   }
 }

--- a/src/heksher.tsx
+++ b/src/heksher.tsx
@@ -1,9 +1,15 @@
-import React, { PropsWithChildren, useDebugValue, useEffect, useMemo, useRef, useSyncExternalStore } from 'react';
+import React, { ReactNode, useDebugValue, useEffect, useMemo, useRef } from 'react';
+import { useSyncExternalStore } from 'use-sync-external-store/shim';
 import { useSubscribeToFields } from './hooks';
 import { SubscribeContext, createSubscribeContext, useSubscribeContext } from './subscribe-context';
 import { dispatchChanges, doesValueHaveFields, fieldUsageDecorator } from './utils';
 
-export interface HeksherProviderProps<THeksherValue> extends PropsWithChildren {
+export interface HeksherProviderProps<THeksherValue> {
+  /**
+   * React's standard children prop. It's required because a Provider must wrap at least one component in order to be useful.
+   */
+  children: ReactNode;
+
   /**
    * The value to pass down to the child components.
    */


### PR DESCRIPTION
- Updated minimum react support to React 16.9.0 - in this version hooks are standard and has most of today's features.
- Changed useSyncExternalStore to be used from an official shim, this is because it was only added to react in version 18
- Made children prop required for Heksher.Provider - originally did that because PropsWithChildren api changed but after some thinking, it does not make any sense to not make it required under a provider.